### PR TITLE
Edited confusing usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Surround your EditText by a MaterialTextField
 <com.github.florent37.materialtextfield.MaterialTextField
         android:layout_width="300dp"
         android:layout_height="wrap_content"
+        app:mtf_labelColor="#666"
         app:mtf_image="@drawable/ic_mail_grey600_24dp"
         >
 
@@ -28,7 +29,6 @@ Surround your EditText by a MaterialTextField
              android:layout_height="wrap_content"
              android:hint="Password"
              android:textColor="#333"
-             android:textColorHint="#666"
              android:textSize="15sp" />
 
 </com.github.florent37.materialtextfield.MaterialTextField>


### PR DESCRIPTION
The following attribute of an EditText does not have any visible effect when used within a MaterialTextField:
```xml
android:textColorHint="#666"
```
 Viewers of the usage example may be confused as to why the attribute does not work upon use in applications. As such, I removed this line for clarity and added the following attribute to its parent view: 
```xml
app:mtf_labelColor="#666"
``` 
It gives the intended effect of specifying the hint colour of an EditText as well as eliminating reader confusion.

